### PR TITLE
Add keybindings to manage status and priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ In your .emacs or init.el:
 
 ## Key bindings
 
+### Creation
+
+In order to quickly create a new item, use `C-c C-n`. It simply adds a new open item and let you type the desired text.
+
 ### Status
 
 When placing the cursor on a line containing an item, some keybindings can help to change its status:
@@ -35,9 +39,9 @@ When placing the cursor on a line containing an item, some keybindings can help 
 - `C-c C-p`: set the item as in progress (`[@]`)
 - `C-c C-a`: set the item as archived, a.k.a obsolete (`[~]`)
 
-Additionally, there is a keybinding that cycle through these statuses:
+Additionally, there is a keybinding that cycle through these status:
 
-- `C-c C-c`: cycle through the different statuses (`open` -> `done` -> `in progress` -> `archived`)
+- `C-c C-c`: cycle through the different status (`open` -> `in progress` -> `done` -> `archived`)
 
 ### Priority
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,25 @@ In your .emacs or init.el:
 (load "~/.emacs.d/xit-mode/xit-mode.el")
 (require 'xit-mode)
 ```
+
+## Key bindings
+
+### Status
+
+When placing the cursor on a line containing an item, some keybindings can help to change its status:
+
+- `C-c C-o`: set the item as open (`[ ]`)
+- `C-c C-d`: set the item as done (`[x]`)
+- `C-c C-p`: set the item as in progress (`[@]`)
+- `C-c C-a`: set the item as archived, a.k.a obsolete (`[~]`)
+
+Additionally, there is a keybinding that cycle through these statuses:
+
+- `C-c C-c`: cycle through the different statuses (`open` -> `done` -> `in progress` -> `archived`)
+
+### Priority
+
+In the same condition, it is possible to change the item's priority with the following keybindings:
+
+- `C-c C-<up>`: increase the priority (by adding a `!`)
+- `C-c C-<down>`: decrease the priority (by removing a `!` or a `.`)

--- a/xit-mode.el
+++ b/xit-mode.el
@@ -34,17 +34,25 @@
 (defvar xit--priority-regexp "\\([\\!|\\.]+ \\)"
   "The regpexp used to search for the priority.")
 
-(defvar xit--checkbox-string-open "[ ] "
+(defvar xit--checkbox-open-string "[ ] "
   "The open checkbox string.")
 
-(defvar xit--checkbox-string-checked "[x] "
+(defvar xit--checkbox-checked-string "[x] "
   "The checked checkbox string.")
 
-(defvar xit--checkbox-string-ongoing "[@] "
+(defvar xit--checkbox-ongoing-string "[@] "
   "The progress checkbox string.")
 
-(defvar xit--checkbox-string-obsolete "[~] "
+(defvar xit--checkbox-obsolete-string "[~] "
   "The obsolete checkbox string.")
+
+(defun xit-new-item ()
+  "Create a new xit item."
+  (interactive)
+  (beginning-of-line)
+  (insert "[ ] \n")
+  (forward-line -1)
+  (end-of-line))
 
 (defun xit--item-replace-checkbox (reg rep)
   "Replace the current item checkbox spotted by REG with REP."
@@ -57,22 +65,22 @@
 (defun xit-item-open ()
   "Set a xit item to open."
   (interactive)
-  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-open))
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-open-string))
 
 (defun xit-item-checked ()
   "Set a xit item to checked."
   (interactive)
-  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-checked))
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-checked-string))
 
 (defun xit-item-ongoing ()
   "Set a xit item to ongoing."
   (interactive)
-  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-ongoing))
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-ongoing-string))
 
 (defun xit-item-obsolete ()
   "Set a xit item to obsolete."
   (interactive)
-  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-obsolete))
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-obsolete-string))
 
 (defun xit-item-cycle ()
   "Cycle through xitem states."
@@ -83,14 +91,14 @@
     (when (re-search-forward xit--checkbox-regexp nil t)
       (let ((checkbox (match-string-no-properties 0)))
         (cond
-         ((string-equal checkbox xit--checkbox-string-open)
-          (replace-match xit--checkbox-string-ongoing))
-         ((string-equal checkbox xit--checkbox-string-ongoing)
-          (replace-match xit--checkbox-string-checked))
-         ((string-equal checkbox xit--checkbox-string-checked)
-          (replace-match xit--checkbox-string-obsolete))
-         ((string-equal checkbox xit--checkbox-string-obsolete)
-          (replace-match xit--checkbox-string-open))
+         ((string-equal checkbox xit--checkbox-open-string)
+          (replace-match xit--checkbox-ongoing-string))
+         ((string-equal checkbox xit--checkbox-ongoing-string)
+          (replace-match xit--checkbox-checked-string))
+         ((string-equal checkbox xit--checkbox-checked-string)
+          (replace-match xit--checkbox-obsolete-string))
+         ((string-equal checkbox xit--checkbox-obsolete-string)
+          (replace-match xit--checkbox-open-string))
          (t (warn "Checkbox not found")))))))
 
 (defun xit-item-inc-priority ()
@@ -118,6 +126,7 @@
 
 (defvar xit-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-n") 'xit-new-item)      ;; n for new
     (define-key map (kbd "C-c C-o") 'xit-item-open)     ;; o for open
     (define-key map (kbd "C-c C-d") 'xit-item-checked)  ;; d for done
     (define-key map (kbd "C-c C-p") 'xit-item-ongoing)  ;; p for progress

--- a/xit-mode.el
+++ b/xit-mode.el
@@ -28,14 +28,105 @@
 
 (defvar xit-mode-hook nil)
 
-;; (defvar xit-mode-map
-;;   (let ((map (make-sparse-keymap)))
-;;     (define-key map "\C-j" 'newline-and-indent)
-;;     map)
-;;   "Keymap for `xit-mode'.")
+(defvar xit--checkbox-regexp "^\\(\\[[ |x|@|~]\\] \\)"
+  "The regpexp used to search for the checkbox.")
 
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.xit\\'" . xit-mode))
+(defvar xit--priority-regexp "\\([\\!|\\.]+ \\)"
+  "The regpexp used to search for the priority.")
+
+(defvar xit--checkbox-string-open "[ ] "
+  "The open checkbox string.")
+
+(defvar xit--checkbox-string-checked "[x] "
+  "The checked checkbox string.")
+
+(defvar xit--checkbox-string-ongoing "[@] "
+  "The progress checkbox string.")
+
+(defvar xit--checkbox-string-obsolete "[~] "
+  "The obsolete checkbox string.")
+
+(defun xit--item-replace-checkbox (reg rep)
+  "Replace the current item checkbox spotted by REG with REP."
+  (save-restriction
+    (narrow-to-region (line-beginning-position) (line-end-position))
+    (goto-char (point-min))
+    (when (re-search-forward reg nil t)
+      (replace-match rep))))
+
+(defun xit-item-open ()
+  "Set a xit item to open."
+  (interactive)
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-open))
+
+(defun xit-item-checked ()
+  "Set a xit item to checked."
+  (interactive)
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-checked))
+
+(defun xit-item-ongoing ()
+  "Set a xit item to ongoing."
+  (interactive)
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-ongoing))
+
+(defun xit-item-obsolete ()
+  "Set a xit item to obsolete."
+  (interactive)
+  (xit--item-replace-checkbox xit--checkbox-regexp xit--checkbox-string-obsolete))
+
+(defun xit-item-cycle ()
+  "Cycle through xitem states."
+  (interactive)
+  (save-restriction
+    (narrow-to-region (line-beginning-position) (line-end-position))
+    (goto-char (point-min))
+    (when (re-search-forward xit--checkbox-regexp nil t)
+      (let ((checkbox (match-string-no-properties 0)))
+        (cond
+         ((string-equal checkbox xit--checkbox-string-open)
+          (replace-match xit--checkbox-string-ongoing))
+         ((string-equal checkbox xit--checkbox-string-ongoing)
+          (replace-match xit--checkbox-string-checked))
+         ((string-equal checkbox xit--checkbox-string-checked)
+          (replace-match xit--checkbox-string-obsolete))
+         ((string-equal checkbox xit--checkbox-string-obsolete)
+          (replace-match xit--checkbox-string-open))
+         (t (warn "Checkbox not found")))))))
+
+(defun xit-item-inc-priority ()
+  "Increase item priority."
+  (interactive)
+  (save-restriction
+    (narrow-to-region (line-beginning-position) (line-end-position))
+    (goto-char (point-min))
+    (if (re-search-forward xit--priority-regexp nil t)
+        (replace-match (concat "!" (match-string-no-properties 1)))
+      (when (re-search-forward xit--checkbox-regexp nil t)
+        (replace-match "\\1! ")))))
+
+(defun xit-item-dec-priority ()
+  "Decrease item priority."
+  (interactive)
+  (save-restriction
+    (narrow-to-region (line-beginning-position) (line-end-position))
+    (goto-char (point-min))
+    (when (re-search-forward xit--priority-regexp nil t)
+      (let ((s (substring (match-string-no-properties 1) 1)))
+        (if (string-equal s " ")
+            (replace-match "")
+          (replace-match s))))))
+
+(defvar xit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-o") 'xit-item-open)     ;; o for open
+    (define-key map (kbd "C-c C-d") 'xit-item-checked)  ;; d for done
+    (define-key map (kbd "C-c C-p") 'xit-item-ongoing)  ;; p for progress
+    (define-key map (kbd "C-c C-a") 'xit-item-obsolete) ;; a for archive
+    (define-key map (kbd "C-c C-c") 'xit-item-cycle)    ;; c for cycle
+    (define-key map (kbd "C-c C-<up>") 'xit-item-inc-priority)
+    (define-key map (kbd "C-c C-<down>") 'xit-item-dec-priority)
+    map)
+  "Keymap for `xit-mode'.")
 
 ;; descriptions disabled until tags in descriptions are resolved.
 ;; right now tags don't display if a description has a face.
@@ -62,7 +153,7 @@
   '((t :inherit (bold underline)))
   "Face used for checkboxes group title"
   :group 'xit-faces)
-  
+
 (defface xit-open-checkbox
   '((t :inherit font-lock-function-name-face))
   "Face used for open checkbox."
@@ -113,15 +204,17 @@
   "Face used for tags."
   :group 'xit-faces)
 
-(defun xit-mode ()
-  "Major mode for [x]it!"
-  (interactive)
+(define-derived-mode xit-mode text-mode "[x]it!"
+  "Major mode for [x]it files."
   (kill-all-local-variables)
-  ;;(use-local-map xit-mode-map)
+  (use-local-map xit-mode-map)
   (setq font-lock-defaults '(xit-mode-font-lock-keywords))
   (setq major-mode 'xit-mode)
   (setq mode-name "[x]it!")
   (run-hooks 'xit-mode-hook))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.xit\\'" . xit-mode))
 
 (provide 'xit-mode)
 ;;; xit-mode.el ends here


### PR DESCRIPTION
Hello,

I would like to introduce a keymap in order to make this mode more interactive.
I added here some keybindings to change the status and the priority of a task. And another on to create a new item.
It is kind of basic for the moment, but I'd like to improve it with some more interactions.

Please feel free to make any suggestion on the current PR, and in any case, thanks for supporting the xit mode !

## Technical changes

- Derive the mode from text-mode
- move autoload at the botttom
- Add the following keybindings:
  - `C-c C-n`: create a new item  (insert `[  ]` and let you type your text)
  - `C-c C-o`: set the item as open (`[ ]`)
  - `C-c C-d`: set the item as done (`[x]`)
  - `C-c C-p`: set the item as in progress (`[@]`)
  - `C-c C-a`: set the item as archived, a.k.a obsolete (`[~]`)
  - `C-c C-c`: cycle through the different statuses (`open` -> `done` -> `in progress` -> `archived`)
  - `C-c C-<up>`: increase the priority (by adding a `!`)
  - `C-c C-<down>`: decrease the priority (by removing a `!` or a `.`)
