### PR TITLE
Issue 5: Imenu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ In your .emacs or init.el:
 (require 'xit-mode)
 ```
 
+## Features
+
+- Syntax highlighting with customizable faces
+- Item state and priority management via keybindings
+- `imenu` support
+
 ## Key bindings
 
 - `C-c C-n` (`M-x xit-new-item`) : Create a new open item
@@ -35,7 +41,9 @@ In your .emacs or init.el:
 - `C-c C-<up>` (`M-x xit-inc-priority-item`) : Increase the priority by adding a `!`
 - `C-c C-<down>` (`M-x xit-dec-priority-item`) : Decrease the priority by removing a `!` or a `.`
 
-## Customizable faces
+## Customizable variables
+
+### Faces
 
 Here is the list of the faces used in the `xit-faces` group:
 
@@ -49,3 +57,10 @@ Here is the list of the faces used in the `xit-faces` group:
 - `xit-obsolete-description-face`
 - `xit-priority-face`
 - `xit-tag-face`
+
+### Imenu
+
+Imenu can be customized via the variable `xit-imenu-function`. Its possible values are:
+
+- `'xit-imenu-groups` to list only groups
+- `'xit-imenu-groups-and-items` to list groups and items

--- a/xit-mode.el
+++ b/xit-mode.el
@@ -92,6 +92,8 @@
 
 (defvar xit-mode-hook nil)
 
+(defvar xit-imenu-function 'xit-imenu-groups-and-items)
+
 (defvar xit--group-title-regexp "^[a-zA-Z]+.*$"
   "The regepx used to search for group titles.")
 
@@ -249,6 +251,53 @@
    `(,xit--tag-regexp 0 'xit-tag-face))
   "Highlighting specification for `xit-mode'.")
 
+;; Imenu support
+
+(defun xit-imenu-groups ()
+  "Extract groups for imenu index from the current file."
+  (let ((imenu-data '()))
+    (save-excursion
+      (goto-char (point-min))
+      (save-match-data
+        (while (re-search-forward xit--group-title-regexp nil t)
+          (push (cons (match-string-no-properties 0)
+                      (car (match-data 1)))
+                imenu-data))))
+    imenu-data))
+
+(defun xit-imenu-groups-and-items ()
+  "Extract groups and items for imenu index from the current file."
+  (let ((imenu-data '())
+        (items-buffer '())
+        (last-group ""))
+    (save-excursion
+      (goto-char (point-min))
+      (while (not (eobp))
+        (let* ((line (substring-no-properties (buffer-substring (point) (point-at-eol))))
+               (trimmed-line (replace-regexp-in-string "\n$" "" line))
+               (item-text (replace-regexp-in-string
+                           xit--checkbox-regexp ""
+                           (replace-regexp-in-string
+                            xit--priority-regexp ""
+                            trimmed-line))))
+          (cond ((string-match xit--checkbox-regexp line)
+                 (push (cons item-text (point)) items-buffer))
+                ((string-match xit--group-title-regexp line)
+                 (setq last-group trimmed-line))
+                ((string-match "" line)
+                 (when (not (null items-buffer))
+                   (if (not (string-equal last-group ""))
+                       (push (cons last-group (nreverse items-buffer)) imenu-data)
+                     (setq imenu-data (append items-buffer imenu-data))))
+                 (setq last-group "")
+                 (setq items-buffer '()))))
+        (beginning-of-line 2))
+      (when (not (null items-buffer))
+        (if (not (string-equal last-group ""))
+            (push (cons last-group (nreverse items-buffer)) imenu-data)
+          (setq imenu-data (append items-buffer imenu-data)))))
+    (nreverse imenu-data)))
+
 ;; Mode definition
 
 (define-derived-mode xit-mode text-mode "[x]it!"
@@ -258,6 +307,8 @@
   (setq font-lock-defaults '(xit-mode-font-lock-keywords))
   (setq major-mode 'xit-mode)
   (setq mode-name "[x]it!")
+  (setq imenu-sort-function 'imenu--sort-by-name)
+  (setq imenu-create-index-function xit-imenu-function)
   (run-hooks 'xit-mode-hook))
 
 ;;;###autoload


### PR DESCRIPTION
Following the roadmap we discussed about , here is a PR for the `imenu support`.

## Reference

- https://github.com/ryanolsonx/xit-mode/issues/5

## Technical changes

- Add a customizable variable `xit-imenu-function` to let the user either chose the mode or set its own custom function
- Add support for "group" and "group and items" in imenu
- README entry

## Screenshots

With value `'xit-imenu-groups`

![Screenshot 2022-09-07 at 14 15 34](https://user-images.githubusercontent.com/235706/188878368-4df509e2-c4a3-419d-8bc3-fe401d444b10.png)

With value `'xit-imenu-groups-and-items`

![Screenshot 2022-09-07 at 14 13 08](https://user-images.githubusercontent.com/235706/188878409-d713fc9b-3c98-4153-bb66-add14da8d0c6.png)
