### PR TITLE
Issue 7: Add documentation for Melpa installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,34 @@
 
 ## Installation
 
-As this is WIP, it's not available on Melpa. When it's more complete, it'll be in Melpa. So for now, to use this, you'll need to:
+### Melpa
 
-### 1. Download the package
+`xit-mode` has a recipe in the [melpa repository](https://github.com/melpa/melpa) to ease its installation.
+
+You can use the command `M-x package-install` and then select the `xit-mode` package to install it automatically.
+
+### use-package
+
+You can also rely on the [use-package](https://github.com/jwiegley/use-package) configuration helper to ease the installation and configuration from your `.emacs` file.
+
+Just add the following snippet to your config file:
+
+``` elisp
+(use-package xit-mode :ensure t)
+```
+
+### Manual
+
+Alternatively, you can still install the mode manually by following these steps:
+
+#### 1. Download the package
 
 ```bash
 cd ~/.emacs.d/
 git clone https://github.com/ryanolsonx/xit-mode
 ```
 
-### 2. Load it in Emacs
+#### 2. Load it in Emacs
 
 In your .emacs or init.el:
 

--- a/xit-mode.el
+++ b/xit-mode.el
@@ -6,7 +6,7 @@
 
 ;; Authors: Ryan Olson <ryolson@me.com>
 ;; URL: https://github.com/ryanolsonx/xit-mode
-;; Version: 0.2
+;; Version: 0.3
 ;; Package-Requires: ((emacs "24.1"))
 ;; Keywords: xit, todo, tools, convinience, project
 
@@ -27,6 +27,7 @@
 
 ;; Versions:
 ;;
+;;   - 0.3 melpa recipe is now available
 ;;   - 0.2 adding interactivity with keybindings and imenu support
 ;;   - 0.1 initial release with syntax color support
 


### PR DESCRIPTION
Update documentation after Melpa recipe has been merged (https://github.com/melpa/melpa/pull/8190).

It is the final touch for https://github.com/ryanolsonx/xit-mode/issues/7