### PR TITLE
Insert dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ In your .emacs or init.el:
 - Syntax highlighting with customizable faces
 - Item state and priority management via keybindings
 - `imenu` support
+- Dates support
 
 ## Key bindings
 
@@ -58,6 +59,7 @@ In your .emacs or init.el:
 - `C-c C-C` (`M-x xit-state-cycle-item `) : Cycle through the different states (`open` -> `ongoing` -> `checked` -> `obsolete`)
 - `C-c C-<up>` (`M-x xit-inc-priority-item`) : Increase the priority by adding a `!`
 - `C-c C-<down>` (`M-x xit-dec-priority-item`) : Decrease the priority by removing a `!` or a `.`
+- `C-c C-w` (`M-x xit-insert-date`) : Insert a formatted date
 
 ## Customizable variables
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Here is the list of the faces used in the `xit-faces` group:
 - `xit-obsolete-description-face`
 - `xit-priority-face`
 - `xit-tag-face`
+- `xit-date-face`
 
 ### Imenu
 

--- a/xit-mode.el
+++ b/xit-mode.el
@@ -90,6 +90,11 @@
   "Face used for tags."
   :group 'xit-faces)
 
+(defface xit-date-face
+  '((t :inherit font-lock-doc-face))
+  "Face used for dates."
+  :group 'xit-faces)
+
 ;; Variables
 
 (defvar xit-mode-hook nil)
@@ -122,6 +127,9 @@
 
 (defvar xit--tag-regexp "#[a-zA-Z0-9\\-_]+"
   "The regpexp used to search for tags.")
+
+(defvar xit--date-regexp "\\-> [0-9]+\\([-|\\/][Q|W]*[0-9]+\\)?\\([-|\\/][0-9]+\\)?"
+  "The regpexp used to search for dates.")
 
 (defvar xit--checkbox-open-string "[ ] "
   "The open checkbox string.")
@@ -250,7 +258,8 @@
      (1 'xit-obsolete-checkbox-face)
      (2 'xit-obsolete-description-face))
    `(,xit--checkbox-priority-regexp 1 'xit-priority-face)
-   `(,xit--tag-regexp 0 'xit-tag-face))
+   `(,xit--tag-regexp 0 'xit-tag-face)
+   `(,xit--date-regexp 0 'xit-date-face))
   "Highlighting specification for `xit-mode'.")
 
 ;; Imenu support

--- a/xit-mode.el
+++ b/xit-mode.el
@@ -27,11 +27,14 @@
 
 ;; Versions:
 ;;
+;;   - 0.4 dates support
 ;;   - 0.3 melpa recipe is now available
 ;;   - 0.2 adding interactivity with keybindings and imenu support
 ;;   - 0.1 initial release with syntax color support
 
 ;;; Code:
+
+(require 'calendar)
 
 ;; Faces
 
@@ -235,6 +238,7 @@
     (define-key map (kbd "C-c C-c") 'xit-state-cycle-item) ;; c for cycle
     (define-key map (kbd "C-c C-<up>") 'xit-inc-priority-item)
     (define-key map (kbd "C-c C-<down>") 'xit-dec-priority-item)
+    (define-key map (kbd "C-c C-w") 'xit-insert-date) ;; w for when
     map)
   "Keymap for `xit-mode'.")
 
@@ -308,6 +312,13 @@
             (push (cons last-group (nreverse items-buffer)) imenu-data)
           (setq imenu-data (append items-buffer imenu-data)))))
     (nreverse imenu-data)))
+
+;; Dates
+
+(defun xit-insert-date (date)
+  "Insert DATE at point."
+  (interactive (list (calendar-read-date)))
+  (insert (format "-> %d-%d-%d" (nth 2 date) (nth 1 date) (nth 0 date))))
 
 ;; Mode definition
 


### PR DESCRIPTION
# Changes

- Support syntax highlighting for all dates described in the specs (`2022`, `2022-04`, `2022-04-12`, `2022-Q4`, `2022-W32`, ...)
- Add a keybinding to invoke a calendar helper and insert the date at point
- Update documentation

# Issue

https://github.com/ryanolsonx/xit-mode/issues/12 